### PR TITLE
Explicitly set Psych gem dependency and version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,14 @@
 PATH
   remote: .
   specs:
-    settingslogic (2.0.9)
+    settingslogic (2.0.10)
+      psych (= 3.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
+    psych (3.1.0)
     rake (10.0.3)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
@@ -24,3 +26,6 @@ DEPENDENCIES
   rake
   rspec
   settingslogic!
+
+BUNDLED WITH
+   1.17.2

--- a/settingslogic.gemspec
+++ b/settingslogic.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "settingslogic"
-  s.version     = "2.0.9"
+  s.version     = "2.0.10"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Ben Johnson"]
   s.email       = ["bjohnson@binarylogic.com"]
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A simple and straightforward settings solution that uses an ERB enabled YAML file and a singleton design pattern.}
   s.description = %q{A simple and straightforward settings solution that uses an ERB enabled YAML file and a singleton design pattern.}
 
+  s.add_dependency 'psych', '3.1.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
 


### PR DESCRIPTION
The original settingslogic repo does not explicitly set a Psych dependency and
instead expects a dependency to exist by proxy. This can cause issues when that
proxy gem upgrades Psych to a version not compatible with settingslogic. This fork
and commit explicitly sets the Psych gem dependency and locks it to version 3.1.0